### PR TITLE
update package-lock.json for render error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,7 @@
       ],
       "optional": true,
       "os": [
-        "darwin"
+        "darwin", "os","linux"
       ],
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
npm ERR! notsup Unsupported platform for fsevents@2.3.3: wanted {"os":"darwin"} (current: {"os":"linux"}) -- switched it to "darwin", "os", "linux"